### PR TITLE
support flat messages

### DIFF
--- a/gen/gogen.go
+++ b/gen/gogen.go
@@ -253,6 +253,11 @@ func (e *Error) Error() string {
 			Description: "Unique message identifier.",
 			Optional:    true,
 		}, {
+			Name:        "sessionId",
+			Ref:         "Target.SessionID",
+			Description: "Session that the message belongs to when using flat access.",
+			Optional:    true,
+		}, {
 			Name:        "method",
 			Ref:         "MethodType",
 			Description: "Event or command type.",

--- a/main.go
+++ b/main.go
@@ -95,11 +95,6 @@ func run() error {
 		*flagCache = filepath.Join(cacheDir, "cdproto-gen")
 	}
 
-	// force GO111MODULE=off
-	if err = os.Setenv("GO111MODULE", "off"); err != nil {
-		return err
-	}
-
 	// get latest versions
 	if *flagChromium == "" {
 		if *flagChromium, err = util.GetLatestVersion(util.Cache{
@@ -146,6 +141,11 @@ func run() error {
 
 	if *flagOut == "" {
 		*flagOut = filepath.Join(os.Getenv("GOPATH"), "src", *flagGoPkg)
+	} else {
+		*flagOut, err = filepath.Abs(*flagOut)
+		if err != nil {
+			return err
+		}
 	}
 
 	// create out directory


### PR DESCRIPTION
Since July 2018, the devtools protocol has supported attaching to
targets with flatten=true. Then, messages are sent and received from the
target via a sessionId field on the Message type itself instead of using
sendMessageToTarget and eventReceivedFromTarget.

Add the optional field to Message, which is necessary to support the
mechanism. It's optional since not specifying a SessionID simply sends a
command to the browser itself.

While at it, make a couple of minor changes to better support generating
the code inside a module. First, follow the GO111MODULES environment
variable set by the user; it's always possible to generate to GOPATH via
GO111MODULES=on. Second, always ensure that the "out" path is absolute,
since the code relies on it. Otherwise -out=. would fail in weird ways.