### PR TITLE
always emit `deltaX` and `deltaY` for `Input.dispatchMouseEvent`

### DIFF
--- a/fixup/fixup.go
+++ b/fixup/fixup.go
@@ -177,6 +177,13 @@ const ModifierCommand Modifier = ModifierMeta
 							p.AlwaysEmit = true
 						}
 					}
+				case "dispatchMouseEvent":
+					for _, p := range c.Parameters {
+						switch p.Name {
+						case "deltaX", "deltaY":
+							p.AlwaysEmit = true
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
Otherwise, the CDP message with the following params:

```json
 {"type":"mouseWheel","x":0,"y":0,"modifiers":0,"deltaY":100}
```
will result in an error:
```json
 {"code":-32602,"message":"'deltaX' and 'deltaY' are expected for mouseWheel event"}
```

Fixes #10

**PS**: I'm not sure is it okay to  send this PR to the `old` branch. It seems that the `old` branch is the one used to generate the current `github.com/chromedp/cdproto` package.