### PR TITLE
add new entries to circularDeps - for 92.0.4515.2

### DIFF
--- a/pdl/dep.go
+++ b/pdl/dep.go
@@ -10,6 +10,7 @@ var circularDeps = map[string]bool{
 	"browser.browsercontextid":            true,
 	"dom.backendnodeid":                   true,
 	"dom.backendnode":                     true,
+	"dom.compatibilitymode":               true,
 	"dom.nodeid":                          true,
 	"dom.node":                            true,
 	"dom.nodetype":                        true,
@@ -24,6 +25,12 @@ var circularDeps = map[string]bool{
 	"page.frameid":                        true,
 	"page.frame":                          true,
 	"page.gatedapifeatures":               true,
+	"page.origintrial":                    true,
+	"page.origintrialstatus":              true,
+	"page.origintrialtoken":               true,
+	"page.origintrialtokenstatus":         true,
+	"page.origintrialtokenwithstatus":     true,
+	"page.origintrialusagerestriction":    true,
 	"page.securecontexttype":              true,
 }
 


### PR DESCRIPTION
CDP introduced some new data types (between `92.0.4501.1` and `92.0.4515.2`) which requires `cdproto-gen` to be changed accordingly.