### PR TITLE
always emit `deltaX` and `deltaY` for `Input.emulateTouchFromMouseEvent`

### DIFF
--- a/diff/diff_unix.go
+++ b/diff/diff_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package diff

--- a/diff/diff_windows.go
+++ b/diff/diff_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package diff

--- a/fixup/fixup.go
+++ b/fixup/fixup.go
@@ -177,7 +177,7 @@ const ModifierCommand Modifier = ModifierMeta
 							p.AlwaysEmit = true
 						}
 					}
-				case "dispatchMouseEvent":
+				case "dispatchMouseEvent", "emulateTouchFromMouseEvent":
 					for _, p := range c.Parameters {
 						switch p.Name {
 						case "deltaX", "deltaY":

--- a/grab.go
+++ b/grab.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/pdl/gen.go
+++ b/pdl/gen.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main


### PR DESCRIPTION
The fix is similar to #11.

Fixes https://github.com/chromedp/chromedp/issues/1067