### PR TITLE
remove the pre-cleanup fixup for page.setDownloadBehavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,15 +197,10 @@ func run() error {
 			continue
 		}
 
-		// TODO: remove this pre-cleanup fixup at some point; right now,
-		// it's necessary as the current Chrome stable release doesn't
-		// yet support the new Browser.setDownloadBehavior.
 		switch d.Domain {
 		case "Page":
 			for _, c := range d.Commands {
 				switch c.Name {
-				case "setDownloadBehavior":
-					c.AlwaysEmit = true
 				case "getLayoutMetrics":
 					for _, t := range c.Returns {
 						t.AlwaysEmit = true


### PR DESCRIPTION
The download events were added to the browser domain in https://github.com/chromium/chromium/commit/f30fb0f0c38e411ce9eb6b75b71cf063c8ebaa16, back to Apr 2021. The commit was shipped in Chrome 91, and the current stable version is 108. So it's time to remove this fixup.