### PR TITLE
[gen/gotpl] Prevents panic on empty method type

### DIFF
--- a/gen/gotpl/extra.qtpl
+++ b/gen/gotpl/extra.qtpl
@@ -364,7 +364,10 @@ func (err ErrUnknownCommandOrEvent) Error() string {
 {% func ExtraMethodTypeTemplate(domains []*pdl.Domain) %}
 // Domain returns the Chrome DevTools Protocol domain of the event or command.
 func (t MethodType) Domain() string {
-	return string(t[:strings.IndexByte(string(t), '.')])
+	if i := strings.IndexByte(string(t), '.'); i != -1 {
+		return string(t[:i])
+	}
+	return ""
 }
 
 // MethodType values.


### PR DESCRIPTION
Original issue here: https://github.com/chromedp/cdproto/issues/36